### PR TITLE
replace vmware_about_facts with vcenter_about_info per ansible doc

### DIFF
--- a/Deploy-VCSA.yml
+++ b/Deploy-VCSA.yml
@@ -31,7 +31,7 @@
         searchpath: '{{ searchpath }}'
     delegate_to: localhost
   - name: Wait for vCenter
-    vmware_about_facts:
+    vmware_about_info:
       hostname: '{{ vcenter_address }}'
       username: 'administrator@vsphere.local'
       password: '{{ vcenter_password }}'


### PR DESCRIPTION
Thanks for the nice work :-)
I adapted the playbook and run with ansible 2.9.13, got the deprecation warning with vmware_about_facts  
https://docs.ansible.com/ansible/latest/modules/vmware_about_facts_module.html

Also the executable permission of the playbook seems to be not needed